### PR TITLE
CocoaPods support

### DIFF
--- a/DLStarRating.podspec
+++ b/DLStarRating.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "DLStarRating"
+  s.version      = "1.0.1"
+  s.summary      = "iOS star rating component."
+  s.homepage     = "https://github.com/dlinsin/DLStarRating"
+  s.license      = 'Eclipse Public License'
+  s.author       = { " David Linsin" => "dlinsin@gmail.com" }
+  s.source       = { :git => "https://github.com/dlinsin/DLStarRating.git", :commit => 'f1b525496cb9954c9a16a64dd72e392179907865' }
+  s.platform     = :ios
+  s.source_files = 'DLStarRating', 'DLStarRating/**/*.{h,m}'
+  s.resource     = "DLStarRating/images/*.png"
+end


### PR DESCRIPTION
This is just a basic spec file, it will need to have the version and git commit updated (ideally it will be a :tag pointing to a 1.0.1 or whatever is appropriate).

You can find the [poodspec documentation](https://github.com/CocoaPods/CocoaPods/wiki/The-podspec-format) here

You can also just install [CocoaPods](http://cocoapods.org/) and generate the default spec yourself, it contains some useful comments.
