### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -3,8 +3,9 @@
 A `UIControl` subclass that behaves similarly as the App Store rating control.
 
 Written by [David Linsin](http://dlinsin.github.com), January 2011.
-
-
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=DLStarRatingDemo%2FDLStarRatingDemo.xcodeproj&amp;target=DLStarRatingDemo&amp;repo_url=git%3A%2F%2Fgithub.com%2Fdlinsin%2FDLStarRating.git&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
 ## Usage
 
 You find all the sources include two sample images under `DLStarRating`. Add the source folder to your project and use the `DLStarRatingControl` in Interface Builder to setup a default 5 star rating control. 


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
