### PR TITLE
Fix delegate not firing when tapping quickly a star instead of dragging

### DIFF
--- a/DLStarRating/DLStarRatingControl.m
+++ b/DLStarRating/DLStarRatingControl.m
@@ -148,6 +148,7 @@
 }
 
 - (void)cancelTrackingWithEvent:(UIEvent *)event {
+	[self.delegate newRating:self :self.rating];
 	[super cancelTrackingWithEvent:event];
 }
 


### PR DESCRIPTION
Fix delegate not firing when tapping quickly a star instead of dragging
